### PR TITLE
Project.xml documentation - added link to android permission list

### DIFF
--- a/learn/resources/command-line-tools/project-files/xml-format.md
+++ b/learn/resources/command-line-tools/project-files/xml-format.md
@@ -223,8 +223,10 @@ The `deployment` attribute can set the minimum iOS version you wish to target. T
 Use `<config:android />` tags to set Android-specific values:
 
     <config:android install-location="preferExternal" />
-    <config:android permission="com.android.vending.BILLING" />
+    <config:android permission="android.permission.INTERNET" />
     <config:android target-sdk-version="16" />
+
+A complete list of Android permissions can be found at the <a href="http://developer.android.com/reference/android/Manifest.permission.html" target="_blank">android developer website</a>.
 
 ### `<architecture />`
 


### PR DESCRIPTION
I also changed the example permission to probably the most commonly used one (and one that's in the Android docs.)
