### PR TITLE
Add API Reference link to main nav bar after Download

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,5 +1,7 @@
 - title: Download
   url: /download/
+- title: API Reference
+  url: http://api.openfl.org
 - title: Showcase
   url: /showcase/
   subitems:


### PR DESCRIPTION
Logically after download a library, users will want to browse its API. If they ever come back to visit the library website they will be looking for documentation such as an API. 

Therefore, the API Reference should be a link in the main nav bar instead of only being tucked inside Learn.