### PR TITLE
[Proposal] Website Changes

### DIFF
--- a/get-involved.html
+++ b/get-involved.html
@@ -4,31 +4,30 @@ title: Get Involved
 permalink: get-involved/
 ---
 
-<p>OpenFL is different than other platforms, OpenFL is designed to keep your options open, to support you in what you want to create and build. Help OpenFL grow and mature! Through your support, OpenFL can continue to improve, to support new platforms, and to deepen support for old ones.</p>
+<p>OpenFL stands apart from other platforms by empowering you with flexibility and freedom to create whatever you envision. With your support, OpenFL can continue to evolve—expanding compatibility with new platforms and enhancing its reliability on existing ones.</p>
 
-<p>Documentation, tutorials and other learning resources are essential to enabling new users to discover how simple it is to create web, desktop, mobile and console games and applications. Whether you are a beginner or a seasoned veteran, learning and reference resources can keep OpenFL accessible and easy-to-use.</p>
+<p>Comprehensive documentation, insightful tutorials, and robust learning resources are critical for helping both beginners and seasoned professionals explore OpenFL’s potential. These resources make it straightforward to develop engaging games and applications for web, desktop, mobile, and console environments.</p>
 
-<p>Through the gracious support of our contributors and sponsors, OpenFL continues to grow and mature. Thanks!</p>
+<p>Thanks to the generous contributions and sponsorship from our community, OpenFL consistently improves and matures. Your support directly enables these advancements, ensuring OpenFL remains accessible, powerful, and user-friendly.</p>
+
+<p>Join us in shaping the future of OpenFL!</p>
 
 <h2>Become a Sponsor</h2>
 
-<p>Your donation can help with OpenFL's web hosting and other operational costs. Just visit Patreon or Open Collective. Thank you!</p>
+<p>Your contribution directly supports OpenFL's web hosting and ongoing operational expenses. To donate, please visit our Open Collective. We greatly appreciate your support!</p>
 
-<div style="text-align: center">
-	<a href="https://www.patreon.com/bePatron?u=87581" data-patreon-widget-type="become-patron-button">Become a member!</a>
-	<script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
-</div>
 <div style="text-align: center">
 	<iframe src="https://opencollective.com/openfl/contribute/button?color=blue" width="338" height="50" frameborder="0" scrolling="no"></iframe>
 </div>
 
-<p>To contribute towards OpenFL development work, visit the individual GitHub Sponsors pages of our dedicated team members. With your help, they'll be able to fix more bugs and add cool, new features. Many thanks!</p>
+<p>To directly support OpenFL development, please consider contributing through the individual donation platforms of our dedicated team members. Your generosity enables the team to resolve issues more efficiently and implement exciting new features. Thank you for your valuable support!</p>
 
 <div class="container">
     <div class="row">
         <div class="col-md-4 text-center">
             <p><a href="https://github.com/sponsors/jgranick"><img class="img-circle" style="max-width:250px" src="/images/get-involved/github-sponsors-jgranick.jpg" alt="Joshua Granick"></a></p>
             <span class="icon-github"></span> <a href="https://github.com/sponsors/jgranick">Joshua Granick on GitHub Sponsors</a>
+	    <span class="icon-patreon"></span> <a href="https://www.patreon.com/bePatron?u=87581">Joshua Granick on Patreon</a>
         </div>
         <div class="col-md-4 text-center">
             <p><a href="https://github.com/dimensionscape"></a><img class="img-circle" style="max-width:250px" src="/images/get-involved/default-chrisspeciale.png" alt="Chris Speciale"></a></p>
@@ -43,8 +42,8 @@ permalink: get-involved/
 
 <h2>Become a Contributor</h2>
 
-<p>If you are a developer, there is always a need for contributors to help make improvements to the platform. Even if you do not fancy yourself an expert, your feedback and input are valuable!</p>
+<p>We always welcome developers to contribute to the growth and improvement of OpenFL. Regardless of your experience level, your contributions, feedback, and ideas are highly valuable to our community.</p>
 
-<p>The first way to contribute is to communicate, speak up and help others on the <a href="https://community.openfl.org">OpenFL forums</a>, or <a href="https://discord.gg/tDgq8EE">chat with us on Discord</a> for better 1:1 communication on feature improvements and other aspects of the development cycle.</p>
+<p>One of the best ways to start contributing is by engaging with others. Join conversations, ask questions, or help fellow users on the <a href="https://community.openfl.org">OpenFL forums</a>. For more direct and immediate communication, <a href="https://discord.gg/tDgq8EE">join our Discord server</a> to discuss feature enhancements and collaborate closely with the development team.</p>
 
-<p>Almost all of the code is available on <a href="https://github.com/openfl">GitHub</a>, even <a href="https://github.com/openfl/www.openfl.org">this website</a>! There are many places and ways that developers can contribute to OpenFL.</p>
+<p>OpenFL's codebase is open-source and hosted on <a href="https://github.com/openfl">GitHub</a>, including <a href="https://github.com/openfl/www.openfl.org">this very website</a>. Explore the repositories to find ways you can help, whether through fixing issues, enhancing documentation, or adding exciting new features.</p>


### PR DESCRIPTION
*Revise get-involved page*

I aimed to rehash some of the pages content to sound a little better and I made some changes to make it clearer about where (and who) funds go to. I also changed some of the wording to omit github sponsors so that team members could list other platforms (like patreon). I still don't have one myself, so maybe its silly that I am listed here, but I plan to add my patreon as well. 

I think it would be cool to also maybe add an extra page to offer a little more personal, short introduction to team members (and future team members?)  with links to their personal pages or projects.

Side note: I think I need to add an icon-patreon class.. I don't think that exists!