### PR TITLE
footer: Add about link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,7 +26,8 @@
           <li><a href="{{ site.baseurl }}/download/">Download</a></li>
           <li><a href="{{ site.baseurl }}/learn/">Learn</a></li>
           <li><a href="{{ site.baseurl }}/showcase/">Showcase</a></li>
-          <li><a href="https://community.openfl.org//">Community</a></li>
+          <li><a href="https://community.openfl.org/">Community</a></li>
+          <li><a href="https://openfl.org/about/">About</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
I created a sort of experimental about page. It's technically live, but unreachable from the main site for now while waiting on feedback and potential adjustments. Leaving this PR here for now.